### PR TITLE
Add support for peerDependenciesMeta.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,9 @@ module.exports = function validatePeerDependencies(parentRoot, options = {}) {
   }
 
   let pkg = require(packagePath);
-  let { peerDependencies } = pkg;
-  let dependencies = pkg.dependencies || {};
+  let { dependencies, peerDependencies, peerDependenciesMeta } = pkg;
+  let hasDependencies = Boolean(dependencies);
+  let hasPeerDependenciesMeta = Boolean(peerDependenciesMeta);
 
   // lazily created as needed
   let missingPeerDependencies = null;
@@ -87,7 +88,7 @@ module.exports = function validatePeerDependencies(parentRoot, options = {}) {
   let invalidPackageConfiguration = null;
 
   for (let packageName in peerDependencies) {
-    if (packageName in dependencies) {
+    if (hasDependencies && packageName in dependencies) {
       if (invalidPackageConfiguration === null) {
         invalidPackageConfiguration = [];
       }
@@ -108,7 +109,16 @@ module.exports = function validatePeerDependencies(parentRoot, options = {}) {
       resolvePeerDependenciesFrom,
       cache === NullCache ? false : undefined
     );
+
     if (peerDepPackagePath === null) {
+      if (
+        hasPeerDependenciesMeta &&
+        packageName in peerDependenciesMeta &&
+        peerDependenciesMeta[packageName].optional
+      ) {
+        continue;
+      }
+
       if (missingPeerDependencies === null) {
         missingPeerDependencies = [];
       }

--- a/index.test.js
+++ b/index.test.js
@@ -64,6 +64,27 @@ describe('validate-peer-dependencies', function () {
     `);
   });
 
+  it('throws an error when peerDependencies that are optional are present but at the wrong version', () => {
+    project.pkg.peerDependencies = {
+      foo: '> 1',
+    };
+    project.pkg.peerDependenciesMeta = {
+      foo: {
+        optional: true,
+      },
+    };
+
+    project.addDevDependency('foo', '1.0.0');
+    project.writeSync();
+
+    expect(() => validatePeerDependencies(project.baseDir))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "test-app has the following unmet peerDependencies:
+
+      	* foo: \`> 1\`; it was resolved to \`1.0.0\`"
+    `);
+  });
+
   it('throws if some peerDependencies are met and others are missing', () => {
     project.pkg.peerDependencies = {
       foo: '> 1',
@@ -123,6 +144,22 @@ describe('validate-peer-dependencies', function () {
     };
 
     project.addDevDependency('foo', '1.0.0');
+    project.writeSync();
+
+    validatePeerDependencies(project.baseDir);
+  });
+
+  it('does not throw when peerDependencies are optional', () => {
+    project.pkg.peerDependencies = {
+      foo: '>= 1',
+    };
+
+    project.pkg.peerDependenciesMeta = {
+      foo: {
+        optional: true,
+      },
+    };
+
     project.writeSync();
 
     validatePeerDependencies(project.baseDir);


### PR DESCRIPTION
`peerDependenciesMeta` provides a way to validate the versioning of a given peer dependency, but to **also** indicate that it is optional.

Fixes https://github.com/rwjblue/validate-peer-dependencies/issues/5
