### PR TITLE
docs: update ember-addon example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,15 +132,32 @@ resolvable from `child`'s on disk location.
 
 Here is an example of what usage by an ember-cli addon would look like:
 
-```js
+```javascript
 'use strict';
 
 const validatePeerDependencies = require('validate-peer-dependencies');
 
 module.exports = {
-  // Having the validation check in "included" hook allows the check to be done only when your addon is included in a 
-  //  build. It means that if consumer try to generate your addon blueprints, the validation check will not be triggered 
-  //  and the addon blueprints will be able to, if configured, automatically install required peerDependencies.
+  // ...snip...
+  init() {
+    this._super.init.apply(this, arguments);
+
+    validatePeerDependencies(__dirname, {
+      resolvePeerDependenciesFrom: this.parent.root,
+    });
+  }
+};
+```
+
+Or alternatively, if it only makes sense for the addon to validate peer deps
+during a build, that would look like:
+
+```javascript
+'use strict';
+
+const validatePeerDependencies = require('validate-peer-dependencies');
+
+module.exports = {
   included(parent) {
     this._super.included.apply(this, arguments);
 

--- a/README.md
+++ b/README.md
@@ -139,12 +139,14 @@ const validatePeerDependencies = require('validate-peer-dependencies');
 
 module.exports = {
   // ...snip...
-  init() {
-    this._super.init.apply(this, arguments);
+  included(parent) {
+    this._super.included.apply(this, arguments);
 
     validatePeerDependencies(__dirname, {
-      resolvePeerDependenciesFrom: this.parent.root,
+      resolvePeerDependenciesFrom: parent.root,
     });
+    
+    return parent;
   }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ Here is an example of what usage by an ember-cli addon would look like:
 const validatePeerDependencies = require('validate-peer-dependencies');
 
 module.exports = {
-  // ...snip...
+  // Having the validation check in "included" hook allows the check to be done only when your addon is included in a 
+  //  build. It means that if consumer try to generate your addon blueprints, the validation check will not be triggered 
+  //  and the addon blueprints will be able to, if configured, automatically install required peerDependencies.
   included(parent) {
     this._super.included.apply(this, arguments);
 


### PR DESCRIPTION
Not really important and very specific to ember-addon example, but if we put `validatePeerDependencies` check in `init` method, then we will not be able to generate addon blueprints, the check will fails because peerDependencies will not be found

It is an unwanted behavior as, most of the time, ember-addon blueprints will automatically install peerDependencies. Putting the check in `included` hook allows blueprints to be run correctly and throws error when building/serving the project if peerDependencies are not found

Current behavior with `init` method ->
![Capture d’écran 2021-10-22 à 17 59 33](https://user-images.githubusercontent.com/56396753/138487332-b13e5f51-d5e5-4b75-b17c-5a078c2bdf31.png)
